### PR TITLE
Do not continue sync script if gitout fails

### DIFF
--- a/root/app/sync.sh
+++ b/root/app/sync.sh
@@ -4,6 +4,9 @@ if [ -n "$HEALTHCHECK_ID" ]; then
 	curl -sS -X POST -o /dev/null "https://hc-ping.com/$HEALTHCHECK_ID/start"
 fi
 
+# If gitout fails we want to avoid triggering the health check.
+set -e
+
 /app/gitout /config/config.toml /data
 
 if [ -n "$HEALTHCHECK_ID" ]; then


### PR DESCRIPTION
We do not want the healthcheck service to appear heathly.