### PR TITLE
Handle failure when getting ResponseData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+
+[[package]]
 name = "ascii"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,12 +312,14 @@ dependencies = [
 name = "gitout"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "git2",
  "graphql_client",
  "reqwest",
  "serde",
  "serde_json",
  "structopt",
+ "thiserror",
  "toml",
 ]
 
@@ -1101,6 +1109,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ serde_json = "1.0"
 structopt = "0.3.14"
 toml = "0.5"
 graphql_client = "0.9.0"
+anyhow = "1.0"
+thiserror = "1.0"
 
 [profile.release]
 codegen-units = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,14 @@ fn main() {
 
 		println!("Querying GitHub information for {0}…", &github.user);
 		io::stdout().flush().unwrap();
-		let user_repos = github::user_repos(&client, &github.user, &github.token);
+		let user_repos = match github::user_repos(&client, &github.user, &github.token) {
+			Ok(repos) => repos,
+			Err(err) => {
+				eprintln!("Failed to get user's repos: {}", err.to_string());
+				std::process::exit(1);
+			}
+		};
+
 		if verbose {
 			dbg!(&user_repos);
 		}


### PR DESCRIPTION
fix #23

added basic error handling in `user_repos`. I'm not sure if you prefer checking leading and trailing whitespace(s) in the token before calling the function.