### PR TITLE
Use explicit argument separator

### DIFF
--- a/src/main/kotlin/com/jakewharton/gitout/Engine.kt
+++ b/src/main/kotlin/com/jakewharton/gitout/Engine.kt
@@ -162,6 +162,7 @@ internal class Engine(
 			command.apply {
 				add("clone")
 				add("--mirror")
+				add("--")
 				add(url)
 				add(repo.name)
 			}


### PR DESCRIPTION
A repo/dir name starting with `-` might be interpreted as a flag (e.g., `-3hello`).